### PR TITLE
Added `jsondiffpatch` for better object diffing

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "diff": "^2.2.1",
     "duplexer": "^0.1.1",
     "figures": "^1.4.0",
+    "jsondiffpatch": "^0.1.41",
     "pretty-ms": "^2.1.0",
     "tap-parser": "^1.2.2",
     "through2": "^2.0.0"


### PR DESCRIPTION
Here's what the output looks like currently
![before](https://cloud.githubusercontent.com/assets/4776422/13189830/cc5c0e1a-d727-11e5-8d1e-2e0ad124914e.jpg)

Here's what it looks like after my changes
![after](https://cloud.githubusercontent.com/assets/4776422/13189840/d6c3d3ce-d727-11e5-81fe-ce43b8dcff81.jpg)

The changes I made just make it easier to read nested objects much easier. For objects that have functions it will still appear in a single line string like it currently does so it won't affect those test cases.

Hope this helps