### PR TITLE
Readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The most human-friendly [TAP reporter](https://github.com/substack/tape#pretty-r
 
 ## How to use
 
-You can use tap-notify in the same way as other [TAP reporters](https://github.com/substack/tape#pretty-reporters).
+You can use tap-diff in the same way as other [TAP reporters](https://github.com/substack/tape#pretty-reporters).
 
 ```
 npm install -g tap-diff
@@ -18,6 +18,13 @@ npm install -g tap-diff
 
 ```
 tape ./*.test.js | tap-diff
+```
+
+tap-diff uses [chalk](https://www.npmjs.com/package/chalk) for adding color, which automatically detects
+color terminals. If you're piping the output and want to force color:
+
+```
+FORCE_COLOR=t tape ./*.test.js | tap-diff
 ```
 
 Or use with `createStream()`:


### PR DESCRIPTION
Turns out that you can use `FORCE_COLOR` because tap-diff uses chalk. This is super useful when using watchers like tape-watch, so I thought it was worth documenting.

I also replaced a tap-notify typo, which should be tap-diff.
